### PR TITLE
configure TLC with -workers auto

### DIFF
--- a/lua/tla.lua
+++ b/lua/tla.lua
@@ -21,6 +21,8 @@ M.check = function()
     "-modelcheck",
     "-coverage",
     "1",
+	"-workers",
+	"auto",
     "-config",
     cfg_file_path,
   }


### PR DESCRIPTION
currently there is no workers config passed to tlc in the TlaCheck script. i believe this defaults to one worker, and using workers auto can get drastically better perf on multicore machines.

should maybe allow configuration instead, but i think this is still an improvement (i tested on my laptop with 10 cpus and had an order of magnitude better states/sec perf).